### PR TITLE
Dockerize honeypot using multi-stage Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+payloads/
+.idea/
+.dockerignore
+.gitignore
+Dockerfile
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# Build environment
+FROM golang:1.17-alpine AS builder
+
+COPY . $GOPATH/src/github.com/Adikso/minecraft-log4j-honeypot
+WORKDIR $GOPATH/src/github.com/Adikso/minecraft-log4j-honeypot
+RUN go install .
+
+# Export binary only from builder environment
+FROM alpine:latest AS runner
+
+COPY --from=builder /go/bin/minecraft-log4j-honeypot /usr/local/bin/minecraft-log4j-honeypot
+
+VOLUME payloads
+EXPOSE 25565
+
+ENTRYPOINT ["/usr/local/bin/minecraft-log4j-honeypot"]

--- a/README.md
+++ b/README.md
@@ -7,10 +7,19 @@ This honeypots runs fake Minecraft server (1.16.5) waiting to be exploited. Payl
 
 ## Running
 
-
+### Natively
 ```
 git clone https://github.com/Adikso/minecraft-log4j-honeypot.git
 cd minecraft-log4j-honeypot
 go build .
 ./minecraft-log4j-honeypot
+```
+
+### Using docker
+```
+git clone https://github.com/Adikso/minecraft-log4j-honeypot.git
+cd minecraft-log4j-honeypot
+docker build -t minecraft-log4j-honeypot .
+mkdir payloads
+docker run --rm -it --mount type=bind,source="${PWD}/payloads",target=/payloads --user=`id -u` -p 25565:25565 minecraft-log4j-honeypot
 ```


### PR DESCRIPTION
Thank you for creating this honeypot!

For my use case I wanted to run it as a docker container so I decided to write a two-stage Dockerfile, that first builds the application and then only copies over the binary to the final image.

I added some basic documentation for how to run it as the current user to make reading the payloads easier.
